### PR TITLE
Simplifying type system and removing unnecessary(?) function

### DIFF
--- a/pygitops/types.py
+++ b/pygitops/types.py
@@ -1,14 +1,4 @@
 from pathlib import Path
 from typing import Union
 
-
-class GitDefaultBranch:
-    """
-    A sentinal / placeholder class used to represent the intention to use the default branch on a repository
-    """
-
-
-GitBranchType = Union[GitDefaultBranch, str]
 PathOrStr = Union[Path, str]
-
-GIT_DEFAULT_BRANCH = GitDefaultBranch()


### PR DESCRIPTION
As discussed in #64, I do not understand the value of the `_get_branch_name` function (especially the part [here](https://github.com/wayfair-incubator/pygitops/blob/main/pygitops/operations.py#L260)).

As I started investigating the value of the `_get_branch_name` function, I experimentally removed it and the type definitions it used. I found that even after these removals, all tests and linters were still passing (w/ 100% test coverage) *and* - in my opinion - the code was more simple and has a better UX (because users no longer have to pass in `pygitops.GIT_DEFAULT_BRANCH` - which can be confusing).

Is there a compelling reason to keep the `_get_branch_name` function and its type definitions?

If merged, this fixes #64.