### PR TITLE
Add workflow for deploying to PyPI

### DIFF
--- a/.github/actions/build-dist/action.sh
+++ b/.github/actions/build-dist/action.sh
@@ -1,0 +1,8 @@
+set -euo pipefail
+
+echo "Ensuring pip is up to date"
+python -m pip install --upgrade pip
+echo "Installing the latest version of pypa/build"
+pip install build
+
+python -m build --sdist --wheel --outdir dist/ .

--- a/.github/actions/build-dist/action.yml
+++ b/.github/actions/build-dist/action.yml
@@ -1,0 +1,8 @@
+name: "Build Python package"
+description: "Build a wheel and sdist for the package"
+runs:
+  using: "composite"
+  steps:
+    - name: "Build wheel"
+      run: "$GITHUB_ACTION_PATH/action.sh"
+      shell: "bash"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,24 +11,23 @@ on:
     types: [published]
 
 jobs:
-  deploy:
-
+  build-and-publish-wheel-to-pypi:
     runs-on: ubuntu-latest
-
+    environment: "Publish Release"
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build wheel
+        uses: ./.github/actions/build-dist
+
+        # v1.4.2 release. Using full SHA for security
+        # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This workflow is the [default one suggested by Github](https://docs.github.com/en/actions/guides/building-and-testing-python#publishing-to-package-registries) except it is triggered when there is a new tag that starts with `v` (e.g. `v0.10.0`).

There is an example of this being used [here](https://github.com/democritus-project/d8s-dates/blob/main/.github/workflows/pypi-publish.yml).

Fixes #85 .