### PR TITLE
Only commit to pypi when release is published

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,9 +4,6 @@
 name: Upload to PyPI
 
 on:
-  push:
-    tags:
-      - 'v*'
   release:
     types: [published]
 


### PR DESCRIPTION
Fixes #104 - this prevents the duplicate runs of the PyPI upload action as seen [here](https://github.com/wayfair-incubator/pygitops/actions/workflows/python-publish.yml).