### PR TITLE
Fixing docs build by adding site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: pygitops Documentation
+site_url: https://wayfair-incubator.github.io/pygitops/
 repo_url: https://github.com/wayfair-incubator/pygitops/
 repo_name: wayfair-incubator/pygitops
 edit_uri: edit/main/docs/


### PR DESCRIPTION
The [site_url field](https://github.com/wayfair-incubator/pygitops/pull/114/checks?check_run_id=2831068352#step:5:8) is now required.