### PR TITLE
Fix Documentation Build Failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,8 +138,7 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-#    if: github.event_name == 'pull_request'
-    if: false
+    if: github.event_name == 'pull_request'
     continue-on-error: true
     steps:
       - name: Check out code

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ flake8==4.0.1
 isort==5.10.1
 mypy==0.920
 mkdocs-material==8.1.2
-mkdocstrings==0.16.2
+mkdocstrings==0.17.0
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.1


### PR DESCRIPTION
### Background

In [this PR](https://github.com/wayfair-incubator/pygitops/pull/178/files#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R141) I disabled the docs action, because it was failing and we needed to release a new feature.

### The Fix

Simply bump mkdocstrings! 