### PR TITLE
Loosen version restriction for gitpython

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ python_requires = >=3.6
 install_requires =
     dataclasses~=0.8; python_version < '3.7'
     filelock~=3.3
-    GitPython>=3.1,<=3.1.18
+    GitPython>=3.1,<3.2
 packages = find:
 
 [options.packages.find]


### PR DESCRIPTION
The version of gitpython we require is pretty strict, so pygitops quickly becomes incompatible with related libraries, like pygithub.