### PR TITLE
Add optional kwargs to push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
         - name: Check out code
           uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
           if: ${{ always() }}
 
         - name: Publish coverage results to Codecov
-          uses: codecov/codecov-action@v2.1.0
+          uses: codecov/codecov-action@v3.1.0
           with:
             file: coverage-${{ matrix.python-version }}.xml
             fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Add kwarg pass-through parameter to `stage_commit_push_changes`, allowing users to provide keyword arguments to `git push`.
+
 ## [0.13.2] - 2022-03-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add kwarg pass-through parameter to `stage_commit_push_changes`, allowing users to provide keyword arguments to `git push`.
 
+### Changed
+
+* Bumped mkdocstrings from 0.17.0 to 0.18.1
+* Bump black from 22.1.0 to 22.3.0
+
+### Removed
+
+* Support for Python 3.6
+
+
 ## [0.13.2] - 2022-03-10
 
 ### Changed

--- a/docs/making-changes-on-feature-branch.md
+++ b/docs/making-changes-on-feature-branch.md
@@ -22,7 +22,7 @@ SOME_DIRECTORY = 'some-directory'
 # create a Repo object in the current directory (see https://gitpython.readthedocs.io/en/stable/tutorial.html#meet-the-repo-type)
 repo = Repo(SOME_DIRECTORY)
 
-with feature_branch(REPO, NEW_BRANCH_NAME):
+with feature_branch(repo, NEW_BRANCH_NAME):
     # create a new file with a list of chores
     (Path(SOME_DIRECTORY) / NEW_FILE_NAME).write_text('- [ ] haircut\n- [ ] groceries\n- [ ] dishes')
 
@@ -61,9 +61,12 @@ from git import Actor, Repo
 
 NEW_BRANCH_NAME = 'some-new-branch'
 ACTOR = Actor('git-username', 'git-email@example.com')
-REPO = Repo(SOME_DIRECTORY)
-COMMIT_MESSAGE = 'automated submodule update
+COMMIT_MESSAGE = 'automated submodule update'
 SOME_SUBMODULE_REPO_NAME = 'some-repo'
+SOME_DIRECTORY = 'some-directory'
+
+# create a Repo object in the current directory (see https://gitpython.readthedocs.io/en/stable/tutorial.html#meet-the-repo-type)
+repo = Repo(SOME_DIRECTORY)
 
 # update submodule's reference to remote upstream, push feature branch with changes
 with feature_branch(repo, NEW_BRANCH_NAME):

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -71,7 +71,7 @@ def stage_commit_push_changes(
     origin = repo.remotes.origin
     if not kwargs_to_push:
         kwargs_to_push = {}
-    push_info = origin.push(branch_name, **kwargs_to_push)[0]
+    push_info = origin.push(branch_name, **kwargs_to_push or {})[0]
 
     _logger.debug(
         f"Issued commit to remote branch: {branch_name}, with resulting summary: {push_info.summary} and flags: {push_info.flags}. (see flag documentation: https://gitpython.readthedocs.io/en/stable/reference.html#git.remote.PushInfo)"

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -25,7 +25,7 @@ def stage_commit_push_changes(
     actor: Actor,
     commit_message: str,
     items_to_stage: Optional[List[Path]] = None,
-    kwargs_to_push: Optional[Dict] = None
+    kwargs_to_push: Optional[Dict] = None,
 ) -> None:
     """
     Handles the logic of persisting filesystem changes to a local repository via a commit to a feature branch.

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -2,7 +2,7 @@ import logging
 import re
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator, List, Optional
+from typing import Dict, Iterator, List, Optional
 
 from filelock import FileLock
 from git import Actor, GitError, Repo
@@ -25,6 +25,7 @@ def stage_commit_push_changes(
     actor: Actor,
     commit_message: str,
     items_to_stage: Optional[List[Path]] = None,
+    kwargs_to_push: Optional[Dict] = None
 ) -> None:
     """
     Handles the logic of persisting filesystem changes to a local repository via a commit to a feature branch.
@@ -37,6 +38,7 @@ def stage_commit_push_changes(
     :param commit_message: Text to be used as the commit message.
     :param items_to_stage: List of files and directories that will be staged for commit, will be inferred if parameter not provided.
         Please use an empty list to signal that there are intentionally no items to stage, and items_to_stage should not be inferred.
+    :param kwargs_to_push: dictionary of arguments to pass to the push operation
     :raises PyGitOpsStagedItemsError: Items to stage are not present or could not be determined.
     :raises PyGitOpsError: There was an error staging, committing, or pushing code.
     """
@@ -67,7 +69,9 @@ def stage_commit_push_changes(
 
     # push changes to the remote branch
     origin = repo.remotes.origin
-    push_info = origin.push(branch_name)[0]
+    if not kwargs_to_push:
+        kwargs_to_push = {}
+    push_info = origin.push(branch_name, **kwargs_to_push)[0]
 
     _logger.debug(
         f"Issued commit to remote branch: {branch_name}, with resulting summary: {push_info.summary} and flags: {push_info.flags}. (see flag documentation: https://gitpython.readthedocs.io/en/stable/reference.html#git.remote.PushInfo)"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,7 +5,7 @@ flake8==4.0.1
 isort==5.10.1
 mypy==0.931
 mkdocs-material==8.2.1
-mkdocstrings==0.17.0
+mkdocstrings==0.18.1
 pytest==7.0.1
 pytest-cov==3.0.0
 pytest-mock==3.6.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 bandit==1.7.1
-black==22.1.0
+black==22.3.0
 bump2version==1.0.1
 flake8==4.0.1
 isort==5.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -21,7 +20,7 @@ classifiers =
 
 [options]
 
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     dataclasses~=0.8; python_version < '3.7'
     filelock~=3.3

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -302,13 +302,20 @@ def test_stage_commit_push_changes__force_push_flag__changes_pushed(tmp_path):
     with feature_branch(local_repo, SOME_FEATURE_BRANCH):
         test_file_path = Path(local_repo.working_dir) / SOME_CONTENT_FILENAME
         test_file_path.write_text("content one")
-        stage_commit_push_changes(local_repo, SOME_FEATURE_BRANCH, SOME_ACTOR, SOME_COMMIT_MESSAGE)
+        stage_commit_push_changes(
+            local_repo, SOME_FEATURE_BRANCH, SOME_ACTOR, SOME_COMMIT_MESSAGE
+        )
 
     branch = local_repo.create_head(SOME_FEATURE_BRANCH, force=True)
     branch.checkout()
     test_file_path.write_text("content two")
-    stage_commit_push_changes(local_repo, SOME_FEATURE_BRANCH, SOME_ACTOR, SOME_COMMIT_MESSAGE, kwargs_to_push={"force": True})
-
+    stage_commit_push_changes(
+        local_repo,
+        SOME_FEATURE_BRANCH,
+        SOME_ACTOR,
+        SOME_COMMIT_MESSAGE,
+        kwargs_to_push={"force": True},
+    )
 
 
 def test_feature_branch__untracked_files_present__raises_pygitops_error(mocker):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -296,6 +296,21 @@ def test_stage_commit_push_changes__no_files_to_stage__raises_pygitops_error(tmp
             )
 
 
+def test_stage_commit_push_changes__force_push_flag__changes_pushed(tmp_path):
+    repos = _initialize_multiple_empty_repos(tmp_path)
+    local_repo = repos.local_repo
+    with feature_branch(local_repo, SOME_FEATURE_BRANCH):
+        test_file_path = Path(local_repo.working_dir) / SOME_CONTENT_FILENAME
+        test_file_path.write_text("content one")
+        stage_commit_push_changes(local_repo, SOME_FEATURE_BRANCH, SOME_ACTOR, SOME_COMMIT_MESSAGE)
+
+    branch = local_repo.create_head(SOME_FEATURE_BRANCH, force=True)
+    branch.checkout()
+    test_file_path.write_text("content two")
+    stage_commit_push_changes(local_repo, SOME_FEATURE_BRANCH, SOME_ACTOR, SOME_COMMIT_MESSAGE, kwargs_to_push={"force": True})
+
+
+
 def test_feature_branch__untracked_files_present__raises_pygitops_error(mocker):
     untracked_file = "foo.py"
     repo = mocker.Mock(


### PR DESCRIPTION
# Description

There are several useful kwargs that a user might want to provide to `push` as part of `stage_commit_push_changes` function, but the function doesn't provide a way to pass these through. 

Similarly to how we allow a user to pass kwargs through to the `clone` function, let's allow the user to pass a dictionary of kwargs to pass to `push`. 

In the future, we may want to additionally allow the user to pass kwargs to the stage, or commit functions, so we must be able to differentiate between these, giving them each their own dictionary parameter.