### PR TITLE
Fix race conditions in mkdir operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Calls to `Path.mkdir` are now made with the `exist_ok=True` parameter, eliminating a race condition when multiple workers are attempting to create the same directory.
+
 ## [0.14.0] - 2022-04-26
 
 ### Added

--- a/pygitops/_util.py
+++ b/pygitops/_util.py
@@ -88,8 +88,7 @@ def checkout_pull_branch(repo: Repo, branch: str) -> None:
 def get_lockfile_path(repo_name: str) -> Path:
     """Get a lockfile to lock a git repo."""
 
-    if not _lockfile_path.is_dir():
-        _lockfile_path.mkdir()
+    _lockfile_path.mkdir(exist_ok=True)
 
     return _lockfile_path / f"{repo_name}_lock_file.lock"
 

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -178,8 +178,7 @@ def get_updated_repo(repo_url: str, clone_dir: PathOrStr, **kwargs) -> Repo:
     clone_dir = Path(clone_dir)
 
     # if clone dir does not exist, create it, and all parent dirs
-    if not clone_dir.exists():
-        clone_dir.mkdir(parents=True)
+    clone_dir.mkdir(parents=True, exist_ok=True)
 
     git_lockfile_path = _get_lockfile_path(str(clone_dir))
 


### PR DESCRIPTION
Previously, `Path.mkdir` operations would throw an exception if the directory already existed. To avoid this, the directory's existence was checked prior to calling `mkdir`. However, in a scenario where multiple workers are attempting to create the same directory, this could potentially lead to a race condition.

To resolve, eliminate the conditional check and simply pass `exist_ok=True` to each `mkdir` call.