### PR TITLE
Specify the initial branch name in tests

### DIFF
--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -742,7 +742,7 @@ def _initialize_repo_with_content(repo_path):
     """
 
     repo_path.mkdir()
-    repo = Repo.init(repo_path)
+    repo = Repo.init(repo_path, initial_branch=GIT_BRANCH_MASTER)
 
     _commit_content(repo, SOME_INITIAL_CONTENT, commit_message="Initial commit")
 


### PR DESCRIPTION
The `test_get_updated_repo__file_operations__repo_present_locally()` test currently fails when run on a machine where the git `init.defaultBranch` option is set to something other than `master`.  This failure occurs because the test does not specify a default branch name but always asserts that a branch called `master` will be created.

This PR forces that relevant `Repo.init()` method to specify the expected branch name to ensure those tests will pass.