### PR TITLE
Enable force checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
 
 ## [0.15.0] - 2022-05-24
 
@@ -92,3 +93,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - First public release!!!
+
+[Unreleased]: https://github.com/wayfair-incubator/pygitops/compare/v0.15.0...main
+[0.15.0]: https://github.com/wayfair-incubator/pygitops/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/wayfair-incubator/pygitops/compare/v0.13.2...v0.14.0
+[0.13.2]: https://github.com/wayfair-incubator/pygitops/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/wayfair-incubator/pygitops/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/wayfair-incubator/pygitops/compare/v0.12.1...v0.13.0
+[0.12.1]: https://github.com/wayfair-incubator/pygitops/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/wayfair-incubator/pygitops/compare/v0.11.1...v0.12.0
+[0.11.1]: https://github.com/wayfair-incubator/pygitops/compare/v0.11.0...v0.11.1
+[0.11.0]: https://github.com/wayfair-incubator/pygitops/compare/v0.10.0...v0.11.0
+[0.10.0]: https://github.com/wayfair-incubator/pygitops/compare/af37d9a...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added optional `force` arg to `checkout_pull_branch`, allowing any uncommitted changes in an existing repository to be discarded. (#246)
+
 ## [0.15.0] - 2022-05-24
 
 ### Changed

--- a/pygitops/_util.py
+++ b/pygitops/_util.py
@@ -42,7 +42,7 @@ def lock_repo(repo: Repo) -> Iterator[None]:
         )
 
 
-def checkout_pull_branch(repo: Repo, branch: str) -> None:
+def checkout_pull_branch(repo: Repo, branch: str, force: bool = False) -> None:
     """
     Pull changes from the specified branch of a repo.
 
@@ -72,11 +72,17 @@ def checkout_pull_branch(repo: Repo, branch: str) -> None:
             f"[Pull Branch] Set tracking branch successful for repo: {repo}, branch: {branch}"
         )
 
-    # checkout local `branch` to working tree
-    repo.heads[branch].checkout()
+    # checkout local `branch` to working tree, optionally discarding changes to the index and working tree
+    repo.heads[branch].checkout(force=force)
     _logger.debug(
         f"[Pull Branch] Checkout local branch successful for repo: {repo}, branch: {branch}"
     )
+
+    if force:
+        repo.git.clean("-df")
+        _logger.debug(
+            f"[Pull Branch] Removed untracked files for repo: {repo}, branch: {branch}"
+        )
 
     # pull the changes from the remote branch
     origin.pull(branch)

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -190,7 +190,9 @@ def get_updated_repo(repo_url: str, clone_dir: PathOrStr, **kwargs) -> Repo:
                 repo = Repo(clone_dir)
                 # pull down latest changes from `branch` if provided in kwargs, deferring to repo default branch
                 branch = kwargs.get("branch") or get_default_branch(repo)
-                _checkout_pull_branch(repo, branch)
+                # destroy any local changes to tracked and untracked files if `force` is provided in kwargs
+                force = kwargs.get("force") or False
+                _checkout_pull_branch(repo, branch, force=force)
                 return repo
 
             return Repo.clone_from(repo_url, clone_dir, **kwargs)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -531,8 +531,12 @@ def test_get_updated_repo__repo_exists_locally__repo_update_performed_against_de
     repo_mock.remotes.origin.pull.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    "force",
+    [True, False],
+)
 def test_get_updated_repo__repo_exists_locally__repo_update_performed_against_provided_branch(
-    mocker, tmp_path
+    mocker, tmp_path, force
 ):
 
     repo_mock = mocker.Mock()
@@ -543,10 +547,14 @@ def test_get_updated_repo__repo_exists_locally__repo_update_performed_against_pr
     )
     mocker.patch("pygitops.operations.Repo", return_value=repo_mock)
 
-    get_updated_repo(SOME_CLONE_REPO_URL, tmp_path, branch=SOME_FEATURE_BRANCH)
+    get_updated_repo(
+        SOME_CLONE_REPO_URL, tmp_path, branch=SOME_FEATURE_BRANCH, force=force
+    )
 
     get_default_branch_mock.assert_not_called()
-    _checkout_pull_branch_mock.assert_called_once_with(repo_mock, SOME_FEATURE_BRANCH)
+    _checkout_pull_branch_mock.assert_called_once_with(
+        repo_mock, SOME_FEATURE_BRANCH, force=force
+    )
 
 
 def test_get_updated_repo__clone_dirs_dne__clone_dirs_created(mocker, tmp_path):


### PR DESCRIPTION
> **Note**
> This PR also includes the changes from #248

Adds an optional `force` arg to `checkout_pull_branch()`, allowing any uncommitted changes to tracked or untracked files in an existing repository to be discarded, avoiding errors.

Closes #246 