### PR TITLE
Fix default branch extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added optional `force` arg to `checkout_pull_branch`, allowing any uncommitted changes in an existing repository to be discarded. (#246)
 
+### Fixed
+
+* Fixed `get_default_branch` not returning the full branch name if it contains dashes or periods (#250)
+
 ## [0.15.0] - 2022-05-24
 
 ### Changed

--- a/docker/devbox.dockerfile
+++ b/docker/devbox.dockerfile
@@ -19,7 +19,10 @@ ENV PIP_NO_CACHE_DIR "true"
 RUN mkdir /app && chown ${UID}:${GID} /app
 
 USER root
-RUN apt-get install git-core && apt-get clean
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports.list \
+    && apt-get update \
+    && apt-get install -y -t buster-backports git-core \
+    && apt-get clean
 
 USER ${_USER}
 

--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -215,7 +215,7 @@ def get_default_branch(repo: Repo) -> str:
     :param repo: git.Repo instance.
     :return: string representing name of default branch.
     """
-    git_ref_regex = r"refs\/remotes\/origin\/(\w*)"
+    git_ref_regex = r"refs\/remotes\/origin\/([\w*\-\.]+)"
     symbolic_ref_head = "refs/remotes/origin/HEAD"
 
     # local repo should be aware of branch objects prior to running the `set-head` command, where an unknown branch might be present

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -718,9 +718,13 @@ def test_get_default_branch__match_index_error__raises_pygitops_error(mocker):
         get_default_branch(repo_mock)
 
 
-def test_get_default_branch__default_branch_returned(tmp_path):
+@pytest.mark.parametrize(
+    "branch_name",
+    ["main", "master", "2.x", "name-with-dashes", "name_with_underscores"],
+)
+def test_get_default_branch__default_branch_returned(tmp_path, branch_name):
 
-    repos = _initialize_multiple_empty_repos(tmp_path)
+    repos = _initialize_multiple_empty_repos(tmp_path, initial_branch=branch_name)
     remote_repo = repos.remote_repo
     local_repo = repos.local_repo
 
@@ -831,7 +835,9 @@ def _assert_branch_state_stage_commit_push_changes__file_removed(
 
 
 # Helper functions for testing git operations
-def _initialize_multiple_empty_repos(base_path) -> MultipleTestingRepos:
+def _initialize_multiple_empty_repos(
+    base_path, initial_branch="main"
+) -> MultipleTestingRepos:
     """
     Helper function used to initialize and configure local, remote, and clone repos for integration testing.
     """
@@ -848,7 +854,7 @@ def _initialize_multiple_empty_repos(base_path) -> MultipleTestingRepos:
     clone_path.mkdir()
 
     # The remote is set up as a bare repository
-    remote_repo = Repo.init(remote_path)
+    remote_repo = Repo.init(remote_path, initial_branch=initial_branch)
 
     # give the remote repo some initial commit history
     new_file_path = remote_path / SOME_CONTENT_FILENAME


### PR DESCRIPTION
The regular expression used to extract default branch names failed to match dash and period characters.  As a result, `get_default_branch()` would return incorrect results.  For example:

| Actual Branch Name | Returned String |
| --- | --- |
| `main` | `main` |
| `2.x` | `2` <-- incorrect |
| `my-default-branch` | `my` <-- incorrect |
| `my_default_branch` | `my_default_branch` |

This PR fixes this issue.

To test this, we also make a slight tweak to the `_initialize_multiple_empty_repos()` helper to set the default branch when the repository is first created.  This requires using the `-b` / `--initial-branch` option added in [`git 2.28`](https://git-scm.com/docs/git-init/2.28.0).  The `devbox` Docker image was using an older version of `git` (`2.20`), so that has been updated to `2.30` [via buster-backports](https://unix.stackexchange.com/a/559444/80744), ensuring the tests pass both locally (via `devbox`) and via GitHub Actions.