### PR TITLE
Ensure the new 'force' kwarg is not passed to 'git clone'

### DIFF
--- a/pygitops/operations.py
+++ b/pygitops/operations.py
@@ -195,6 +195,8 @@ def get_updated_repo(repo_url: str, clone_dir: PathOrStr, **kwargs) -> Repo:
                 _checkout_pull_branch(repo, branch, force=force)
                 return repo
 
+            # remove 'force' from kwargs if present, as it is not supported by clone
+            kwargs.pop("force", None)
             return Repo.clone_from(repo_url, clone_dir, **kwargs)
         except GitError as e:
             clean_repo_url = _scrub_github_auth(repo_url)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -504,12 +504,18 @@ def test_get_updated_repo__repo_dne__kwargs_passed_to_clone_from(mocker, tmp_pat
 
     clone_from_mock = mocker.patch("pygitops.operations.Repo.clone_from")
 
-    some_kwargs = {"some_arg": "some-value", "another_arg": "another-value"}
+    some_kwargs = {
+        "some_arg": "some-value",
+        "another_arg": "another-value",
+        "force": True,
+    }
 
     get_updated_repo(SOME_CLONE_REPO_URL, tmp_path, **some_kwargs)
 
     clone_from_mock.assert_called_once_with(
-        SOME_CLONE_REPO_URL, tmp_path, **some_kwargs
+        SOME_CLONE_REPO_URL,
+        tmp_path,
+        **{"some_arg": "some-value", "another_arg": "another-value"},
     )
 
 


### PR DESCRIPTION
The new `force` option added via #249 was being passed to `git clone` which does not support or need this option; it should only be used for checkouts when the repository exists.  This PR fixes that issue.